### PR TITLE
Update GitHub release badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![check & fix styling](https://github.com/guanguans/ai-commit/actions/workflows/php-cs-fixer.yml/badge.svg)](https://github.com/guanguans/ai-commit/actions)
 [![codecov](https://codecov.io/gh/guanguans/ai-commit/branch/main/graph/badge.svg?token=URGFAWS6S4)](https://codecov.io/gh/guanguans/ai-commit)
 [![Latest Stable Version](https://poser.pugx.org/guanguans/ai-commit/v)](https://packagist.org/packages/guanguans/ai-commit)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/guanguans/ai-commit)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/guanguans/ai-commit)](https://github.com/guanguans/ai-commit/releases/latest)
 [![Total Downloads](https://poser.pugx.org/guanguans/ai-commit/downloads)](https://packagist.org/packages/guanguans/ai-commit)
 [![License](https://poser.pugx.org/guanguans/ai-commit/license)](https://packagist.org/packages/guanguans/ai-commit)
 


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Updated the GitHub release badge in the `README.md` file to include a hyperlink.
- The badge now links directly to the latest release page on GitHub.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Make GitHub release badge link clickable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated the GitHub release badge link to be clickable.<br> <li> Added a hyperlink to the latest release page.<br>


</details>


  </td>
  <td><a href="https://github.com/guanguans/ai-commit/pull/185/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information